### PR TITLE
Added option for rounded rectangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ export type DrawContinuousOptions = {
     lineWidth?: "thin" | "default" | "thick" | number;
     strokeColor?: string;
     slices?: number;
-    roundedRadius?: number;
+    barRadius?: number;
 }
 ```
 
 - `lineWidth` (`number` | `string`): the width of the lines that make up the wave; if a thickness string is provided, it will be translated into a percentage of the canvas's width, if a number is provided it will be used a `px` value. **Default:** `"default"`.
 - `strokeColor` (`string`): the color of the wave; **Default:** `"#000"`.
 - `slices` (`number`): the number of slices drawn onto the canvas to make up the wave; **Default:** `100`.
-- `roundedRadius` (`number`): the border radius of each bar, setting `0` will draw a normal rectangle; **Default:** `0`.
+- `barRadius` (`number`): the border radius of each bar, setting `0` will draw a normal rectangle; **Default:** `0`.
 ##### Current Visualizer
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ export type DrawContinuousOptions = {
     lineWidth?: "thin" | "default" | "thick" | number;
     strokeColor?: string;
     slices?: number;
+    roundedRadius?: number;
 }
 ```
 
 - `lineWidth` (`number` | `string`): the width of the lines that make up the wave; if a thickness string is provided, it will be translated into a percentage of the canvas's width, if a number is provided it will be used a `px` value. **Default:** `"default"`.
 - `strokeColor` (`string`): the color of the wave; **Default:** `"#000"`.
 - `slices` (`number`): the number of slices drawn onto the canvas to make up the wave; **Default:** `100`.
-
+- `roundedRadius` (`number`): the border radius of each bar, setting `0` will draw a normal rectangle; **Default:** `0`.
 ##### Current Visualizer
 
 ```typescript

--- a/src/common/draw/options.ts
+++ b/src/common/draw/options.ts
@@ -9,14 +9,14 @@ export interface DrawOptions {
    */
   strokeColor?: string;
   /**
-   * The thickness of the line used to draw the wave.
+   * The thickness of the bar used to draw the wave.
    *
    * If a number is provided, it will be used as a `px` value.
    * If a thickness string is provided, it will be transformed into a percentage of the canvas width.
    *
    * @default "default"
    */
-  lineWidth?: number | "thick" | "thin" | "default";
+  rectWidth?: number | "thick" | "thin" | "default";
 }
 
 /**
@@ -24,5 +24,5 @@ export interface DrawOptions {
  */
 export const defaultDrawOptions: DrawOptions = {
   strokeColor: "#000",
-  lineWidth: 2,
+  rectWidth: 2,
 };

--- a/src/continuous/draw/impure.ts
+++ b/src/continuous/draw/impure.ts
@@ -8,20 +8,20 @@ import { widthFromOption } from "../../common/draw/pure";
 export function drawContinuousWave(
   canvas: HTMLCanvasElement,
   audioHistory: number[],
-  options: DrawContinuousOptions = defaultOptions,
+  options: DrawContinuousOptions = defaultOptions
 ) {
   const context = canvas.getContext("2d");
   if (!context) return;
 
-  const { strokeColor = "#000000", lineWidth = "default", slices = 100 } = options;
+  const { strokeColor = "#000000", lineWidth = "default", slices = 100, roundedRadius = 0 } = options;
   const { height, width } = canvas;
 
-  context.lineWidth = widthFromOption(lineWidth, width);
+  const w = widthFromOption(lineWidth, width);
+  context.lineWidth = w;
   context.strokeStyle = strokeColor;
 
   context.clearRect(0, 0, width, height);
   context.beginPath();
-  context.moveTo(0, height);
 
   const sliceWidth = width / slices;
 
@@ -35,9 +35,12 @@ export function drawContinuousWave(
 
     const x = i * sliceWidth;
 
-    context.moveTo(x, start);
-    context.lineTo(x, end);
+    if (roundedRadius <= 0) {
+      context.rect(x, start, w, end - start);
+    } else {
+      context.roundRect(x, start, w, end - start, roundedRadius);
+    }
   }
 
-  context.stroke();
+  context.fill();
 }

--- a/src/continuous/draw/impure.ts
+++ b/src/continuous/draw/impure.ts
@@ -19,6 +19,8 @@ export function drawContinuousWave(
   const w = widthFromOption(lineWidth, width);
   context.lineWidth = w;
   context.strokeStyle = strokeColor;
+  context.fillStyle = strokeColor;
+
 
   context.clearRect(0, 0, width, height);
   context.beginPath();

--- a/src/continuous/draw/impure.ts
+++ b/src/continuous/draw/impure.ts
@@ -13,14 +13,11 @@ export function drawContinuousWave(
   const context = canvas.getContext("2d");
   if (!context) return;
 
-  const { strokeColor = "#000000", lineWidth = "default", slices = 100, roundedRadius = 0 } = options;
+  const { strokeColor = "#000000", rectWidth = "default", slices = 100, barRadius = 0 } = options;
   const { height, width } = canvas;
 
-  const w = widthFromOption(lineWidth, width);
-  context.lineWidth = w;
-  context.strokeStyle = strokeColor;
+  const w = widthFromOption(rectWidth, width);
   context.fillStyle = strokeColor;
-
 
   context.clearRect(0, 0, width, height);
   context.beginPath();
@@ -37,10 +34,10 @@ export function drawContinuousWave(
 
     const x = i * sliceWidth;
 
-    if (roundedRadius <= 0) {
+    if (barRadius <= 0) {
       context.rect(x, start, w, end - start);
     } else {
-      context.roundRect(x, start, w, end - start, roundedRadius);
+      context.roundRect(x, start, w, end - start, barRadius);
     }
   }
 

--- a/src/continuous/draw/options.ts
+++ b/src/continuous/draw/options.ts
@@ -14,15 +14,15 @@ export interface DrawContinuousOptions extends DrawOptions {
   /**
    * Border radius of the bar
    *
-   * 0 will draw a normal rect
+   * 0 will draw a normal rectangle
    *
    * @default 0
    */
-  roundedRadius?: number;
+  barRadius?: number;
 }
 
 export const defaultOptions: DrawContinuousOptions = {
   ...defaultDrawOptions,
   slices: 100,
-  roundedRadius: 0,
+  barRadius: 0,
 };

--- a/src/continuous/draw/options.ts
+++ b/src/continuous/draw/options.ts
@@ -10,9 +10,19 @@ export interface DrawContinuousOptions extends DrawOptions {
    * @default 100
    */
   slices?: number;
+
+  /**
+   * Border radius of the bar
+   *
+   * 0 will draw a normal rect
+   *
+   * @default 0
+   */
+  roundedRadius?: number;
 }
 
-export const defaultOptions = {
+export const defaultOptions: DrawContinuousOptions = {
   ...defaultDrawOptions,
   slices: 100,
+  roundedRadius: 0,
 };

--- a/src/current/draw/impure.ts
+++ b/src/current/draw/impure.ts
@@ -18,16 +18,12 @@ export function drawCurrentWave(
   const context = canvas.getContext("2d");
   if (!context) return;
 
-  const {
-    strokeColor = "#000",
-    lineWidth = "default",
-    heightNorm = 1,
-  } = options;
+  const { strokeColor = "#000", rectWidth = "default", heightNorm = 1 } = options;
   const { height, width } = canvas;
 
   const sliceWidth = width / audioData.length;
 
-  context.lineWidth = widthFromOption(lineWidth, width);
+  context.lineWidth = widthFromOption(rectWidth, width);
   context.strokeStyle = strokeColor;
 
   context.clearRect(0, 0, width, height);


### PR DESCRIPTION
## Description
- Fixes: #2
- Moved the draw from stroke lines to filled `rect` and `roundRect`.
- Now `DrawContinuousOption` has `barRadius`, which will set the border radius of the bars.

**Test Code**:
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Canvas</title>
  </head>
  <body>
    <canvas height="200" width="400" id="c"></canvas>
    <script type="module" src="./index.js"></script>
  </body>
</html>

```
```js
import { continuousVisualizer } from "./sound-visualizer/lib/index.mjs";

async function init() {
  const c = document.getElementById("c");
  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
  continuousVisualizer(stream, c, { slices: 30, lineWidth: 5, barRadius: 50 }).start();
}
init();
```

**Preview:**

![Screenshot (6)](https://github.com/ej-shafran/sound-visualizer/assets/40920737/f8665afd-d1d7-4aef-a6d9-ce78a1f7875e)
