### PR TITLE
AudioContext disposal & Singleton Analyser per MediaStream

### DIFF
--- a/src/helpers/impure.ts
+++ b/src/helpers/impure.ts
@@ -2,6 +2,8 @@ export * from "../common/draw/impure";
 export * from "../continuous/draw/impure";
 export * from "../current/draw/impure";
 
+const activeAnalysers = new Map<string, { audioContext: AudioContext, analyser: AnalyserNode }>();
+
 /**
  * Takes all the necessary steps to get the byteTimeDomainData analysis for a MediaStream,
  * returning two functions that analyse the audio at a given moment.
@@ -16,8 +18,17 @@ export * from "../current/draw/impure";
  * @impure this function connects to (and alters) global state
  **/
 export function startAnalysis(audio: MediaStream) {
-  const audioContext = new window.AudioContext();
-  const analyser = audioContext.createAnalyser();
+  let activeAnalyser = activeAnalysers.get(audio.id);
+  if (!activeAnalyser) {
+    const audioContext = new window.AudioContext();
+    activeAnalyser = { 
+      audioContext,
+      analyser: audioContext.createAnalyser()
+    }
+    activeAnalysers.set(audio.id, activeAnalyser);
+  }
+  const { audioContext, analyser } = activeAnalyser;
+
   const dataArray = new Uint8Array(analyser.frequencyBinCount);
   const source = audioContext.createMediaStreamSource(audio);
   source.connect(analyser);
@@ -30,6 +41,9 @@ export function startAnalysis(audio: MediaStream) {
   function disconnect() {
     source.disconnect();
     analyser.disconnect();
+    audioContext.close().then(() => {
+      activeAnalysers.delete(audio.id);
+    });
   }
 
   return { analyse, disconnect };


### PR DESCRIPTION
As discussed in this [https://github.com/ej-shafran/sound-visualizer/issues/4](issue), in this PR I'm disposing the AudioContext properly on disconnect and making sure that only one AudioContext and Analyser exists per MediaStream.